### PR TITLE
Fix recursive strategy regression with event realization

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a regression where :func:`~hypothesis.strategies.recursive` with ``max_leaves`` stopped generating nested structures, causing tests to fail with "Unsatisfiable" errors after the addition of unconditional event realization for solver-based backends (:issue:`4638`).
+
+The fix makes event realization conditional, applying it only when needed (when observability is enabled or when using solver-based backends), avoiding disruption to internal state during recursive strategy retry loops.

--- a/hypothesis-python/src/hypothesis/core.py
+++ b/hypothesis-python/src/hypothesis/core.py
@@ -1300,14 +1300,19 @@ class StateForActualGivenExecution:
             # Conditional here so we can save some time constructing the payload; in
             # other cases (without coverage) it's cheap enough to do that regardless.
             #
-            # Note that we have to unconditionally realize data.events, because
-            # the statistics reported by the pytest plugin use a different flow
-            # than observability, but still access symbolic events.
+            # Realize data.events for solver-based backends (which use symbolic
+            # values) and when observability is enabled. For the standard provider,
+            # skip realization to avoid disrupting internal state (e.g., breaking
+            # retry loops in recursive strategies). See issue #4638.
 
-            try:
-                data.events = data.provider.realize(data.events)
-            except BackendCannotProceed:
-                data.events = {}
+            # Only realize if observability is enabled, or if this provider uses
+            # symbolic values (avoid_realization=True indicates solver-based backends
+            # that need explicit realization).
+            if observability_enabled() or data.provider.avoid_realization:
+                try:
+                    data.events = data.provider.realize(data.events)
+                except BackendCannotProceed:
+                    data.events = {}
 
             if observability_enabled():
                 if runner := getattr(self, "_runner", None):

--- a/hypothesis-python/tests/cover/test_recursive.py
+++ b/hypothesis-python/tests/cover/test_recursive.py
@@ -75,6 +75,30 @@ def test_issue_1502_regression(s):
     pass
 
 
+def test_recursive_with_max_leaves_can_generate_nested_structures():
+    # Regression test for issue #4638
+    # st.recursive() with max_leaves should be able to generate nested structures
+    useful_values = st.booleans() | st.integers() | st.text()
+    useful_list = st.lists(st.deferred(lambda: useful_values), max_size=5)
+    useful_dict = st.dictionaries(st.text(), st.deferred(lambda: useful_values), max_size=5)
+
+    json = st.dictionaries(
+        st.text(),
+        st.recursive(
+            useful_values,
+            lambda x: useful_list | useful_dict,
+            max_leaves=20,
+        ),
+        max_size=10,
+    )
+
+    # Should be able to find examples with nested lists
+    def has_list_value(d):
+        return any(isinstance(v, list) for v in d.values())
+
+    find_any(json, has_list_value)
+
+
 @pytest.mark.parametrize(
     "s",
     [


### PR DESCRIPTION
Make data.events realization conditional rather than unconditional to avoid
disrupting internal state during recursive strategy retry loops. The
realization is now only performed when observability is enabled or when
using solver-based backends that produce symbolic values requiring
conversion to concrete values.