### PR TITLE
Handle unhashable entries in sys.modules when collecting local constants

### DIFF
--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes a crash when :obj:`sys.modules` contains unhashable values,
+such as ``types.SimpleNamespace`` objects (:issue:`4660`).

--- a/hypothesis-python/RELEASE.rst
+++ b/hypothesis-python/RELEASE.rst
@@ -1,4 +1,4 @@
 RELEASE_TYPE: patch
 
 This patch fixes a crash when :obj:`sys.modules` contains unhashable values,
-such as ``types.SimpleNamespace`` objects (:issue:`4660`).
+such as :class:`~types.SimpleNamespace` objects (:issue:`4660`).

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -312,7 +312,7 @@ def _get_local_constants() -> Constants:
     # with other threads loading a module before we set _sys_modules_len.
     if (sys_modules_len := len(sys.modules)) != _sys_modules_len:
         new_modules = []
-        for name, module in sys.modules.items():
+        for name, module in list(sys.modules.items()):
             try:
                 seen = module in _seen_modules
             except TypeError:

--- a/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
+++ b/hypothesis-python/src/hypothesis/internal/conjecture/providers.py
@@ -18,7 +18,6 @@ from contextlib import AbstractContextManager, contextmanager
 from functools import cached_property
 from random import Random
 from sys import float_info
-from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -274,7 +273,9 @@ _local_constants = Constants(
 # are all modules, not necessarily local ones. This lets us quickly see which
 # modules are new without an expensive path.resolve() or is_local_module_file
 # cache lookup.
-_seen_modules: set[ModuleType] = set()
+# We track by module object when hashable, falling back to the module name
+# (str key in sys.modules) for unhashable entries like SimpleNamespace.
+_seen_modules: set = set()
 _sys_modules_len: int | None = None
 
 
@@ -310,20 +311,28 @@ def _get_local_constants() -> Constants:
     # careful: store sys.modules length when we first check to avoid race conditions
     # with other threads loading a module before we set _sys_modules_len.
     if (sys_modules_len := len(sys.modules)) != _sys_modules_len:
-        # set(_seen_modules) shouldn't typically be required, but I have run into
-        # a "set changed size during iteration" error here when running
-        # test_provider_conformance_crosshair.
-        new_modules = set(sys.modules.values()) - set(_seen_modules)
+        new_modules = []
+        for name, module in sys.modules.items():
+            try:
+                seen = module in _seen_modules
+            except TypeError:
+                # unhashable module (e.g. SimpleNamespace); fall back to name
+                seen = name in _seen_modules
+            if not seen:
+                new_modules.append((name, module))
         # Repeated SortedSet unions are expensive. Do the initial unions on a
         # set(), then do a one-time union with _local_constants after.
         new_constants = Constants()
-        for module in new_modules:
+        for name, module in new_modules:
             if (
                 module_file := getattr(module, "__file__", None)
             ) is not None and is_local_module_file(module_file):
                 new_constants |= constants_from_module(module)
+            try:
+                _seen_modules.add(module)
+            except TypeError:
+                _seen_modules.add(name)
         _local_constants |= new_constants
-        _seen_modules.update(new_modules)
         _sys_modules_len = sys_modules_len
 
     # if we add any new constant, invalidate the constant cache for permitted values.

--- a/hypothesis-python/tests/conjecture/test_local_constants.py
+++ b/hypothesis-python/tests/conjecture/test_local_constants.py
@@ -9,6 +9,8 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 import math
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -92,3 +94,14 @@ def test_actual_collection(monkeypatch, tmp_path):
         pass
 
     f()
+
+
+def test_unhashable_sys_modules_entry(monkeypatch):
+    # Regression test for https://github.com/HypothesisWorks/hypothesis/issues/4660
+    # Some packages (e.g. cog) place unhashable objects like SimpleNamespace
+    # in sys.modules. This should not crash _get_local_constants.
+    monkeypatch.setattr(providers, "_sys_modules_len", None)
+    monkeypatch.setattr(providers, "_seen_modules", set())
+    monkeypatch.setitem(sys.modules, "_unhashable_test_mod", SimpleNamespace())
+
+    providers._get_local_constants()


### PR DESCRIPTION
Some packages (e.g. cog) place unhashable objects like SimpleNamespace
in sys.modules. This caused a TypeError when _get_local_constants tried
to build a set from sys.modules.values(). Fix by catching TypeError on
the membership check and falling back to tracking by module name (the
str key in sys.modules) for unhashable entries.

https://claude.ai/code/session_01PQkqWu11828t7hwzAyR1sZ