### PR TITLE
Vary dict iteration order in fixed_dictionaries

### DIFF
--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -4,4 +4,4 @@ RELEASE_TYPE: minor
 order of the dicts it generates, rather than always placing the required keys
 first, to help find bugs in code which is sensitive to key order
 (:issue:`3906`).  Examples still shrink towards the original order; if you need
-a specific order, construct it explicitly with e.g. ``st.tuples(...).map(...)``.
+a specific order, use :func:`~hypothesis.strategies.builds` instead.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+:func:`~hypothesis.strategies.fixed_dictionaries` now generates ``dict``\ s
+with varied iteration orders, rather than always placing the required keys
+first (in the order they were passed) followed by the optional keys.  Since
+``dict`` iteration order has been observable since Python 3.7, this helps to
+find bugs in code which is sensitive to key order (:issue:`3906`).
+
+The set of keys - and therefore the distribution of dictionary sizes - is
+unchanged, and examples still shrink towards the original key order.  We only
+vary the order of plain ``dict``\ s; if you pass an ``OrderedDict`` (or another
+subclass) the declared order is preserved, on the basis that it may be
+semantically meaningful.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -1,12 +1,7 @@
 RELEASE_TYPE: minor
 
-:func:`~hypothesis.strategies.fixed_dictionaries` now generates ``dict``\ s
-with varied iteration orders, rather than always placing the required keys
-first (in the order they were passed) followed by the optional keys.  Since
-``dict`` iteration order has been observable since Python 3.7, this helps to
-find bugs in code which is sensitive to key order (:issue:`3906`).
-
-The set of keys - and therefore the distribution of dictionary sizes - is
-unchanged, and examples still shrink towards the original key order.  If you
-need a specific key order, construct it explicitly, e.g. with
-``st.tuples(...).map(...)``.
+:func:`~hypothesis.strategies.fixed_dictionaries` now varies the iteration
+order of the dicts it generates, rather than always placing the required keys
+first, to help find bugs in code which is sensitive to key order
+(:issue:`3906`).  Examples still shrink towards the original order; if you need
+a specific order, construct it explicitly with e.g. ``st.tuples(...).map(...)``.

--- a/hypothesis/RELEASE.rst
+++ b/hypothesis/RELEASE.rst
@@ -7,7 +7,6 @@ first (in the order they were passed) followed by the optional keys.  Since
 find bugs in code which is sensitive to key order (:issue:`3906`).
 
 The set of keys - and therefore the distribution of dictionary sizes - is
-unchanged, and examples still shrink towards the original key order.  We only
-vary the order of plain ``dict``\ s; if you pass an ``OrderedDict`` (or another
-subclass) the declared order is preserved, on the basis that it may be
-semantically meaningful.
+unchanged, and examples still shrink towards the original key order.  If you
+need a specific key order, construct it explicitly, e.g. with
+``st.tuples(...).map(...)``.

--- a/hypothesis/src/hypothesis/internal/conjecture/utils.py
+++ b/hypothesis/src/hypothesis/internal/conjecture/utils.py
@@ -77,6 +77,19 @@ def identity(v: T) -> T:
     return v
 
 
+def fisher_yates_shuffle(data: "ConjectureData", ls: list[T]) -> None:
+    """Shuffle ``ls`` in place, drawing from ``data``.
+
+    Reversed Fisher-Yates shuffle: swap each element with itself or with a
+    later element.  This shrinks i==j for each element, i.e. towards no change,
+    so a shuffled sequence shrinks back to its original order.  We don't
+    consider the last element as it's always a no-op.
+    """
+    for i in range(len(ls) - 1):
+        j = data.draw_integer(i, len(ls) - 1)
+        ls[i], ls[j] = ls[j], ls[i]
+
+
 def check_sample(
     values: type[enum.Enum] | Sequence[T], strategy_name: str
 ) -> Sequence[T]:

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -396,11 +396,11 @@ class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
     def do_draw(self, data: ConjectureData) -> dict[Any, Any]:
         context = current_build_context()
         arg_labels: ArgLabelsT = {}
-        value = type(self.mapping)()
+        pairs: list[tuple[Any, Any]] = []
 
         for key, strategy in self.mapping.items():
             with context.track_arg_label(str(key)) as arg_label:
-                value[key] = data.draw(strategy)
+                pairs.append((key, data.draw(strategy)))
             arg_labels |= arg_label
 
         if self.optional is not None:
@@ -416,8 +416,20 @@ class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
                 remaining[-1], remaining[j] = remaining[j], remaining[-1]
                 key = remaining.pop()
                 with context.track_arg_label(str(key)) as arg_label:
-                    value[key] = data.draw(self.optional[key])
+                    pairs.append((key, data.draw(self.optional[key])))
                 arg_labels |= arg_label
+
+        # Vary the iteration order of the resulting dict (#3906).  We permute
+        # *after* choosing which optional keys to include, so the set of keys -
+        # and thus the length distribution - is unaffected; only order varies.
+        # Permutations shrink towards the original order, i.e. required keys in
+        # declared order followed by optional keys.  We only do this for plain
+        # dicts, where iteration order is incidental; for an OrderedDict (or
+        # other subclass) the declared order may be semantically meaningful.
+        dict_type = type(self.mapping)
+        if dict_type is dict:
+            pairs = data.draw(st.permutations(pairs))
+        value = dict_type(pairs)
 
         if arg_labels:
             context.known_object_printers[IDKey(value)].append(

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -419,12 +419,8 @@ class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
                     pairs.append((key, data.draw(self.optional[key])))
                 arg_labels |= arg_label
 
-        # Vary the iteration order of the resulting dict (#3906).  We shuffle
-        # *after* choosing which optional keys to include, so the set of keys -
-        # and thus the length distribution - is unaffected; only order varies.
-        # The shuffle shrinks towards the original order, i.e. required keys in
-        # declared order followed by optional keys.  Callers who need a specific
-        # key order should build it themselves, e.g. tuples(...).map(dict).
+        # Vary the dict's iteration order (#3906).  We shuffle after choosing
+        # the optional keys, so only order varies, not the set of keys.
         cu.fisher_yates_shuffle(data, pairs)
         value = type(self.mapping)(pairs)
 

--- a/hypothesis/src/hypothesis/strategies/_internal/collections.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/collections.py
@@ -419,17 +419,14 @@ class FixedDictStrategy(SearchStrategy[dict[Any, Any]]):
                     pairs.append((key, data.draw(self.optional[key])))
                 arg_labels |= arg_label
 
-        # Vary the iteration order of the resulting dict (#3906).  We permute
+        # Vary the iteration order of the resulting dict (#3906).  We shuffle
         # *after* choosing which optional keys to include, so the set of keys -
         # and thus the length distribution - is unaffected; only order varies.
-        # Permutations shrink towards the original order, i.e. required keys in
-        # declared order followed by optional keys.  We only do this for plain
-        # dicts, where iteration order is incidental; for an OrderedDict (or
-        # other subclass) the declared order may be semantically meaningful.
-        dict_type = type(self.mapping)
-        if dict_type is dict:
-            pairs = data.draw(st.permutations(pairs))
-        value = dict_type(pairs)
+        # The shuffle shrinks towards the original order, i.e. required keys in
+        # declared order followed by optional keys.  Callers who need a specific
+        # key order should build it themselves, e.g. tuples(...).map(dict).
+        cu.fisher_yates_shuffle(data, pairs)
+        value = type(self.mapping)(pairs)
 
         if arg_labels:
             context.known_object_printers[IDKey(value)].append(

--- a/hypothesis/src/hypothesis/strategies/_internal/core.py
+++ b/hypothesis/src/hypothesis/strategies/_internal/core.py
@@ -87,6 +87,7 @@ from hypothesis.internal.conjecture.utils import (
     calc_label_from_name,
     check_sample,
     combine_labels,
+    fisher_yates_shuffle,
     identity,
 )
 from hypothesis.internal.entropy import get_seeder_and_restorer
@@ -1942,13 +1943,8 @@ class PermutationStrategy(SearchStrategy):
         self.values = values
 
     def do_draw(self, data):
-        # Reversed Fisher-Yates shuffle: swap each element with itself or with
-        # a later element.  This shrinks i==j for each element, i.e. to no
-        # change.  We don't consider the last element as it's always a no-op.
         result = list(self.values)
-        for i in range(len(result) - 1):
-            j = data.draw_integer(i, len(result) - 1)
-            result[i], result[j] = result[j], result[i]
+        fisher_yates_shuffle(data, result)
         return result
 
 

--- a/hypothesis/src/hypothesis/vendor/pretty.py
+++ b/hypothesis/src/hypothesis/vendor/pretty.py
@@ -975,8 +975,8 @@ def _fixeddict_pprinter(
             return p.text("{...}")
 
         get = lambda k: _get_slice_comment(p, arg_labels, k)
-        # Preserve mapping key order, then any optional keys (deduped)
-        keys = list(dict.fromkeys(k for k in [*mapping, *obj] if k in obj))
+        # Print in the dict's actual (possibly permuted) iteration order.
+        keys = list(obj)
         has_comments = any(get(k) for k in keys)
 
         with p.group(indent=4, open="{", close=""):

--- a/hypothesis/tests/cover/test_simple_collections.py
+++ b/hypothesis/tests/cover/test_simple_collections.py
@@ -9,7 +9,6 @@
 # obtain one at https://mozilla.org/MPL/2.0/.
 
 from collections import OrderedDict
-from random import Random
 
 import pytest
 
@@ -28,7 +27,7 @@ from hypothesis.strategies import (
     tuples,
 )
 
-from tests.common.debug import assert_simple_property, find_any, minimal
+from tests.common.debug import find_any, minimal
 from tests.common.utils import flaky
 
 
@@ -79,13 +78,11 @@ def test_sets_are_size_bounded(xs):
     assert 2 <= len(xs) <= 10
 
 
-def test_ordered_dictionaries_preserve_keys():
-    r = Random()
-    keys = list(range(100))
-    r.shuffle(keys)
-    assert_simple_property(
-        fixed_dictionaries(OrderedDict([(k, booleans()) for k in keys])),
-        lambda x: list(x.keys()) == keys,
+def test_fixed_dictionaries_vary_key_order():
+    keys = list(range(10))
+    find_any(
+        fixed_dictionaries({k: booleans() for k in keys}),
+        lambda x: list(x.keys()) != keys,
     )
 
 


### PR DESCRIPTION
## Summary

This PR modifies `fixed_dictionaries` to vary the iteration order of generated dictionaries, helping find bugs in code that is sensitive to key ordering. Previously, dictionaries always had required keys first followed by optional keys in a fixed order.

## Key Changes

- **New utility function**: Added `fisher_yates_shuffle()` to `hypothesis/internal/conjecture/utils.py` that performs a reversed Fisher-Yates shuffle, shrinking towards the original order
- **Updated `fixed_dictionaries`**: Modified the `do_draw` method in `collections.py` to:
  - Collect key-value pairs in a list instead of building the dict directly
  - Shuffle the pairs using the new `fisher_yates_shuffle()` function
  - Construct the final dict from the shuffled pairs
  - This ensures only iteration order varies, not the set of keys
- **Refactored `permutations` strategy**: Extracted the shuffle logic from `core.py` to use the new shared `fisher_yates_shuffle()` utility
- **Updated pretty-printing**: Modified `vendor/pretty.py` to print dicts in their actual (possibly permuted) iteration order rather than reconstructing a canonical order
- **Updated test**: Changed `test_ordered_dictionaries_preserve_keys` to `test_fixed_dictionaries_vary_key_order` to verify that key order actually varies
- **Added changelog entry**: Created `RELEASE.rst` documenting this as a minor feature

## Implementation Details

The shuffle implementation shrinks towards the original order by using a reversed Fisher-Yates approach: each element can be swapped with itself (no change) or with a later element. This ensures that when Hypothesis shrinks failing examples, it naturally moves back towards the original ordering.

https://claude.ai/code/session_01MUo34UvHAsURLeBXDmsx29